### PR TITLE
Remove uuid dependency; use a built-in id generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "react-dom": "16.14.0",
     "react-scripts": "3.4.4",
     "sha1": "1.1.1",
-    "use-persisted-state": "0.3.3",
-    "uuid": "7.0.3"
+    "use-persisted-state": "0.3.3"
   },
   "devDependencies": {
     "typescript": "3.9.10"

--- a/src/Boid.js
+++ b/src/Boid.js
@@ -1,5 +1,9 @@
 import React, { useEffect } from "react";
-import { v4 as uuidv4 } from "uuid";
+
+// simple monotonic id generator for boids (unique per page session); ids are
+// only used as React keys and for neighbor/self identity comparisons
+let boidSeq = 0;
+const nextBoidId = () => `boid-${boidSeq++}`;
 
 export const generateNewBoid = () => {
   return {
@@ -7,7 +11,7 @@ export const generateNewBoid = () => {
     y: undefined,
     speed: undefined,
     infectedTime: undefined,
-    id: uuidv4(),
+    id: nextBoidId(),
     radius: 2,
     heading: Math.random() * 2 * Math.PI - Math.PI,
     vision: 35,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11391,11 +11391,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"


### PR DESCRIPTION
## Why

The Dependabot PR bumping `uuid` 7 → 14 fails the Vercel build with:

```
./src/Boid.js
Cannot find module: 'uuid'. Make sure this package is installed.
```

uuid 14 (and any version since ~v9) declares its entry point only via the
package.json `exports` field, which **webpack 4** (bundled in `react-scripts`
3.4.4) does not support. So the module can't be resolved even though it installs.

## What

Boid ids are only used as React keys and for neighbor/self identity comparisons,
so there's no need for the dependency at all:

- `Boid.js` — replace `uuidv4()` with a tiny monotonic counter (`boid-0`, `boid-1`, …)
- `package.json` — drop `uuid`
- `yarn.lock` — regenerated

This fixes the build **and** clears the uuid Dependabot alert permanently. The
existing `dependabot/npm_and_yarn/uuid-14.0.0` PR can be closed as moot after merge.

## Verified

- No `uuid` references remain in `src`
- Production build passes on Node 24 (the exact config that was failing on Vercel)
- Runtime smoke test: a run still spreads infection normally with no page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)