### PR TITLE
Interface tweaks: auto-run, full-height About, run-until-clear + scrolling graph, last-run summary

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -54,7 +54,7 @@ export default function App() {
   const [simHistory, setSimHistory] = useState({});
   const [isPaused, setIsPaused] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
-  const [showSimpleMenu, setShowSimpleMenu] = useState(true);
+  const [showSimpleMenu, setShowSimpleMenu] = useState(false);
   const [showReplay, setShowReplay] = useState(false);
   // const [freeStyleMode, toggleFreeStyleMode] = useReducer(v => !v, false);
   const [flockSize, setFlockSize] = useState(BUNCH_SIZE);
@@ -63,6 +63,10 @@ export default function App() {
   // read the latest simState from effects without re-subscribing them
   const simStateRef = useRef(simState);
   simStateRef.current = simState;
+  // becomes true after the canvas has been measured at least once; gates the
+  // one-time auto-start so the first run uses the real (fluid) canvas size
+  const [canvasMeasured, setCanvasMeasured] = useState(false);
+  const autoStartedRef = useRef(false);
 
   // population slider ceiling scales with the canvas area (~2x the default)
   const flockSizeMax = Math.max(40, areaToPopulation(canvasWidth * canvasHeight, 2));
@@ -78,16 +82,18 @@ export default function App() {
   // measure the space the canvas fills and keep the drawing buffer in sync
   useEffect(() => {
     const el = canvasWrapRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
+    if (!el) return;
     const measure = () => {
       const w = Math.floor(el.clientWidth);
       const h = Math.floor(el.clientHeight);
       if (w > 0 && h > 0) {
         setCanvasWidth(w);
         setCanvasHeight(h);
+        setCanvasMeasured(true);
       }
     };
     measure();
+    if (typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
@@ -105,6 +111,19 @@ export default function App() {
     if (simStateRef.current === "running") return;
     setBoidsNormal(createBunch(flockSize, 0, canvasWidth, canvasHeight));
   }, [canvasWidth, canvasHeight, flockSize]);
+
+  // on first load, immediately start an unconstrained run so the first thing
+  // visitors see is the boids in motion (rather than the menu). Waits for the
+  // canvas to be measured so the run uses the real fluid size.
+  useEffect(() => {
+    if (autoStartedRef.current || !canvasMeasured || !boidsNormalCtx) return;
+    autoStartedRef.current = true;
+    const pop = areaToPopulation(canvasWidth * canvasHeight);
+    setFlockSize(pop);
+    const newBoids = createBunch(pop, 0, canvasWidth, canvasHeight);
+    setBoidsNormal(infectRandomBoid(newBoids));
+    setSimState("running");
+  }, [canvasMeasured, boidsNormalCtx, canvasWidth, canvasHeight]);
 
   useEffect(() => {
     if (simState === "running") {

--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,20 @@ const StopIcon = () => (
   </svg>
 );
 
+// build a summary of a run that just ended.
+// reason: "cleared" (no infected left) | "stopped" (manually stopped)
+const buildSummary = (reason, boids, startMs) => {
+  const total = boids.length;
+  const everSick = boids.filter(
+    b => b.state === "infected" || b.state === "immune" || b.state === "dead"
+  ).length;
+  return {
+    reason,
+    pctSick: total > 0 ? Math.round((everSick / total) * 100) : 0,
+    durationMs: startMs ? Date.now() - startMs : 0
+  };
+};
+
 export default function App() {
   const [boidsNormalCtx, setBoidsNormalCtx] = useState();
   // const [boidsSDCtx, setBoidsSDCtx] = useState();
@@ -67,6 +81,9 @@ export default function App() {
   // one-time auto-start so the first run uses the real (fluid) canvas size
   const [canvasMeasured, setCanvasMeasured] = useState(false);
   const autoStartedRef = useRef(false);
+  // wall-clock start of the current run, and the summary of the last one
+  const runStartRef = useRef(null);
+  const [summary, setSummary] = useState(null);
 
   // population slider ceiling scales with the canvas area (~2x the default)
   const flockSizeMax = Math.max(40, areaToPopulation(canvasWidth * canvasHeight, 2));
@@ -128,6 +145,8 @@ export default function App() {
   useEffect(() => {
     if (simState === "running") {
       setShowSimpleMenu(false);
+      runStartRef.current = Date.now();
+      setSummary(null);
     }
   }, [simState]);
 
@@ -157,6 +176,7 @@ export default function App() {
 
   // stop the current run and bring the menu back
   const stopRun = () => {
+    setSummary(buildSummary("stopped", boidsNormal, runStartRef.current));
     setSimState("done");
     setShowSimpleMenu(true);
   };
@@ -185,6 +205,7 @@ export default function App() {
   const notifySimDone = useCallback(
     boidData => {
       if (boidData && simState === 'running') {
+        setSummary(buildSummary("cleared", boidsNormal, runStartRef.current));
         setSimState("done");
         setShowSimpleMenu(true);
       }
@@ -243,6 +264,7 @@ export default function App() {
               setFlockSize={setFlockSize}
               flockSize={flockSize}
               setShowSimpleMenu={setShowSimpleMenu}
+              summary={summary}
             />
           )}
           {showReplay && <ReplayMenu />}

--- a/src/GraphCanvas.js
+++ b/src/GraphCanvas.js
@@ -138,31 +138,28 @@ export default function GraphCanvas({
     const numInfected = boids.filter(b => b.state === "infected").length;
     const numImmune = boids.filter(b => b.state === "immune").length;
     if (shouldUpdateBoidGraph()) {
-      if (
-        (numInfected === 0 && numImmune > 0) ||
-        boidGraph.length >= canvasWidth
-      ) {
-        // we are done
+      if (numInfected === 0 && numImmune > 0) {
+        // no infected left -> the run is over
         setIsDone(true);
         setIsGraphDone(true);
       } else {
-        // update graph
+        // append the new sample, keeping only the last canvasWidth of them so
+        // the graph scrolls: once full, old samples fall off the left edge and
+        // new ones enter from the right
         setBoidGraph(boidGraph => {
-          // only add to boidGraph if we have canvas space to show it
-          if (boidGraph.length < canvasWidth) {
-            return [
-              ...boidGraph,
-              {
-                numTotal: boids.length,
-                numNormal: boids.filter(b => b.state === "normal").length,
-                numInfected: boids.filter(b => b.state === "infected").length,
-                numImmune: boids.filter(b => b.state === "immune").length,
-                numDead: boids.filter(b => b.state === "dead").length
-              }
-            ];
-          }
-          // setIsGraphDone(true);
-          return boidGraph;
+          const next = [
+            ...boidGraph,
+            {
+              numTotal: boids.length,
+              numNormal: boids.filter(b => b.state === "normal").length,
+              numInfected: boids.filter(b => b.state === "infected").length,
+              numImmune: boids.filter(b => b.state === "immune").length,
+              numDead: boids.filter(b => b.state === "dead").length
+            }
+          ];
+          return next.length > canvasWidth
+            ? next.slice(next.length - canvasWidth)
+            : next;
         });
       }
     }

--- a/src/SimpleMenu.js
+++ b/src/SimpleMenu.js
@@ -14,7 +14,8 @@ const SimpleMenu = ({
   reset,
   setShowAbout,
   flockSize,
-  setShowSimpleMenu
+  setShowSimpleMenu,
+  summary
 }) => {
   const QUICK_ISO_FACTOR = 77;
   const QUICK_SD_FACTOR = 33; // 0 to 40
@@ -126,6 +127,27 @@ const SimpleMenu = ({
       >
         about
       </button>
+      {summary && (
+        <div className="simSummary">
+          <div className="simSummaryTitle">last run</div>
+          <div className="simSummaryRow">
+            <span>got sick:</span>
+            <span>{summary.pctSick}% of population</span>
+          </div>
+          <div className="simSummaryRow">
+            <span>ended:</span>
+            <span>
+              {summary.reason === "cleared"
+                ? "no more infected"
+                : "manually stopped"}
+            </span>
+          </div>
+          <div className="simSummaryRow">
+            <span>time to immunity:</span>
+            <span>{(summary.durationMs / 1000).toFixed(1)}s</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -269,6 +269,41 @@ div.simpleMenu {
   z-index: 3;
 }
 
+.simSummary {
+  margin-top: 6px;
+  padding: 6px 8px;
+  background-color: #454545;
+  border: 2px solid black;
+  color: #ffcc00;
+  font-family: "VT323", monospace;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 8px;
+  row-gap: 2px;
+}
+
+.simSummaryTitle {
+  grid-column: 1 / -1;
+  text-align: center;
+  border-bottom: 1px solid black;
+  padding-bottom: 2px;
+  margin-bottom: 2px;
+}
+
+/* let each row's two spans flow into the parent grid so the label column is
+   sized to the widest label and the colons line up */
+.simSummaryRow {
+  display: contents;
+}
+
+.simSummaryRow > span {
+  padding: 0;
+}
+
+.simSummaryRow > span:first-child {
+  text-align: right;
+}
+
 div.replayMenu {
   display: flex;
   justify-content: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -292,11 +292,12 @@ div.replayMenu {
 div.about {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   position: absolute;
   left: 50%;
-  top: 25px;
+  top: 20px;
+  bottom: 20px;
   transform: translateX(-50%);
+  box-sizing: border-box;
   background-color: #454545;
   color: white;
   border: 4px solid black;
@@ -304,7 +305,6 @@ div.about {
   z-index: 1;
   width: 75%;
   max-width: 600px;
-  max-height: 80%;
   font-family: "Roboto", sans-serif;
 }
 
@@ -316,8 +316,8 @@ div.scrollable {
   font-family: "Roboto", sans-serif;
   font-size: medium;
   overflow-y: scroll;
-  height: 475px;
-  max-height: 60vh;
+  flex: 1 1 auto;
+  min-height: 0;
   border-top: 5px solid #454545;
 }
 


### PR DESCRIPTION
A batch of interface/UX tweaks.

## Changes

- **Auto-run on load** — instead of showing the menu, the app immediately starts an unconstrained run so the first thing visitors see is the boids in motion. Waits for the canvas to be measured (so the run uses the real fluid size) and fires exactly once.

- **Full-height About modal** — the info modal now spans nearly the full page height (top/bottom 20px), with the scrollable content flex-growing to fill it, instead of stopping partway down.

- **Run until no infected remain + scrolling graph** — a run now ends only when the infection clears (`numInfected === 0 && numImmune > 0`), not when the graph fills. The population graph became a sliding window of the last `canvasWidth` samples, so once full, old samples scroll off the left and new ones enter from the right.

- **"Last run" summary** — when a run stops, a summary appears below the menu showing:
  - % of the population that is or got sick (infected + immune + dead)
  - how it ended: "no more infected" vs "manually stopped"
  - time to immunity (run duration)

  Label colons are aligned via a 2-column grid.

## Verification

All changes verified via headless-Chrome screenshots and behavioral checks (desktop + mobile widths):
- auto-run starts on load; boids fill the fluid canvas
- About modal ~96% of viewport height
- a 48s slow run scrolled continuously and ended only when infection cleared
- summary shows correct %/reason/time for both manual-stop and natural-clear
- production build passes on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)