### PR TITLE
Ignore build artifacts, local env files, and local tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,23 @@
 node_modules/
 .env
+
+# production build
+/build
+
+# testing
+/coverage
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# misc
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local tooling
+.claude/


### PR DESCRIPTION
`.gitignore` only covered `node_modules/` and `.env`, which is how a stray `build/` directory (left behind by a production build check) got committed and had to be cleaned up in a follow-up chore commit. This adds the standard Create React App ignores so it can't recur.

## Added to .gitignore
- `/build` — production build output
- `/coverage` — test coverage
- `.env.local`, `.env.*.local` — local env files
- `.DS_Store`, `npm-debug.log*`, `yarn-debug.log*`, `yarn-error.log*`
- `.claude/` — local Claude Code tooling dir

Verified with `git check-ignore` that `build/`, `coverage/`, `.env.local`, and `.claude/` are now ignored. No tracked files are affected (nothing currently committed matches these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)