### PR TITLE
Interface tweaks: drop 'fine tuned' menu item, About X-close + themed scrollbar

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -3,14 +3,13 @@ import React from "react";
 const About = ({ setShowAbout }) => {
   return (
     <div className="about">
-      <div
-        style={{
-          width: "100%",
-          marginRight: "5px"
-        }}
-      >
-        <button style={{ width: "100%" }} onClick={() => setShowAbout(false)}>
-          close
+      <div className="aboutHeader">
+        <button
+          className="aboutClose"
+          aria-label="close"
+          onClick={() => setShowAbout(false)}
+        >
+          ×
         </button>
       </div>
       <div className="scrollable">

--- a/src/SimpleMenu.js
+++ b/src/SimpleMenu.js
@@ -5,9 +5,7 @@ import { track } from "./analytics";
 
 const SimpleMenu = ({
   setIsolationFactor,
-  isolationFactor,
   setSdFactor,
-  sdFactor,
   canvasWidth,
   canvasHeight,
   setBoids,
@@ -76,19 +74,6 @@ const SimpleMenu = ({
     setBoids(infectRandomBoid(newBoids));
   };
 
-  const handleRegularRun = () => {
-    track("run_start", { source: "fine_tuned" });
-    reset();
-    setSimState("running");
-    const newBoids = createBunch(
-      flockSize,
-      isolationFactor,
-      canvasWidth,
-      canvasHeight
-    );
-    setBoids(infectRandomBoid(newBoids));
-  }
-
   return (
     <div className="simpleMenu">
       <div
@@ -123,9 +108,6 @@ const SimpleMenu = ({
         iso constrained: sd:0.0 iso:{QUICK_ISO_FACTOR}
       </button>
       <button onClick={handleBothConstrained}>both constrained: sd:{formatSDFactor(QUICK_SD_FACTOR)} iso:{QUICK_ISO_FACTOR}</button>
-      <button onClick={handleRegularRun} >
-        fine tuned: sd:{formatSDFactor(sdFactor)} iso:{isolationFactor}
-      </button>
       <button
         onClick={() => {
           track("about_opened");

--- a/src/styles.css
+++ b/src/styles.css
@@ -343,17 +343,55 @@ div.about {
   font-family: "Roboto", sans-serif;
 }
 
-div.about > button {
-  width: 100%;
+.aboutHeader {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 5px;
+}
+
+.aboutClose {
+  font-family: "VT323", monospace;
+  font-size: x-large;
+  line-height: 1;
+  color: #ffcc00;
+  background-color: #454545;
+  border: 2px solid black;
+  padding: 0 8px;
+  cursor: pointer;
+}
+
+.aboutClose:hover {
+  color: #fbff00;
+  background-color: #353535;
 }
 
 div.scrollable {
   font-family: "Roboto", sans-serif;
   font-size: medium;
-  overflow-y: scroll;
+  overflow-y: auto;
   flex: 1 1 auto;
   min-height: 0;
   border-top: 5px solid #454545;
+  scrollbar-width: thin;
+  scrollbar-color: #ffcc00 #2a2a2a;
+}
+
+div.scrollable::-webkit-scrollbar {
+  width: 8px;
+}
+
+div.scrollable::-webkit-scrollbar-track {
+  background: #2a2a2a;
+}
+
+div.scrollable::-webkit-scrollbar-thumb {
+  background-color: #ffcc00;
+  border-radius: 4px;
+  border: 2px solid #2a2a2a;
+}
+
+div.scrollable::-webkit-scrollbar-thumb:hover {
+  background-color: #fbff00;
 }
 
 div.about > h2 {


### PR DESCRIPTION
Small UI polish.

## Changes

- **Remove the "fine tuned" menu item** — redundant with the play button, which already starts a run using the current slider values. Also removes the unused `handleRegularRun` handler and the `sdFactor`/`isolationFactor` value props it required.

- **About: upper-right "×" close button** — replaces the full-width "close" bar with a small `×` button in the top-right corner, styled like the app's other buttons.

- **About: themed scrollbar** — the scrollable area switches from `overflow-y: scroll` (always-visible bar) to `auto`, and gets a thin yellow-on-dark scrollbar via `::-webkit-scrollbar` (Chrome/Safari/Edge) and `scrollbar-width`/`scrollbar-color` (Firefox).

## Verification

Driven headless (desktop + mobile):
- menu no longer lists "fine tuned"; other presets intact
- the About `×` sits in the top-right and closes the modal; no leftover full-width "close" button
- scrollable computes `overflow-y: auto` and only scrolls when content overflows
- production build passes on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)