### PR TITLE
Drop the attribution line from the footer

### DIFF
--- a/src/Footer.js
+++ b/src/Footer.js
@@ -3,7 +3,6 @@ import React from "react";
 const Footer = () => (
   <div className="appFooter">
     <div>&copy; Pheirce Bytes, LLC. All rights reserved.</div>
-    <div>This delightful tool was built by Pheirce Bytes, LLC.</div>
     <div>
       Love this? Let's build something delightful together.{" "}
       <a href="mailto:hello@pheircebytes.com">hello@pheircebytes.com</a>


### PR DESCRIPTION
Updates the footer per the revised spec: keep the copyright and the call-to-action, drop the "This delightful tool was built by Pheirce Bytes, LLC." attribution line.

Footer is now two lines:
- © Pheirce Bytes, LLC. All rights reserved.
- Love this? Let's build something delightful together. → `mailto:hello@pheircebytes.com`

Everything else is unchanged (© glyph, muted text with the email as the accented link, compact retro styling, bottom-pinned, responsive).

Verified at desktop and mobile widths (two lines, correct mailto link, no overflow); production build passes on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)